### PR TITLE
fix(ci): grant contents write permission to gh-pages deploy

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -67,6 +67,9 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+
     strategy:
       matrix:
         node-version: [24]


### PR DESCRIPTION
## Problem
The `deploy` job failed after merging the Angular 22 upgrade with:
```
remote: Permission to eresearchqut/angular-password-strength-meter.git denied to github-actions[bot].
... error: 403
```

## Cause
The default `GITHUB_TOKEN` is read-only, so `JamesIves/github-pages-deploy-action` cannot push to the `gh-pages` branch.

## Fix
Grant `contents: write` permission to the `deploy` job.

> Note: this only works if the repo's **Settings → Actions → General → Workflow permissions** allows workflows to request write (i.e. not forced read-only). If the deploy still 403s, that setting must be enabled.